### PR TITLE
docs: extended README.md about gradle.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # camunda-spring-boot-quickstarter
 Dockerized quick-start template for a Camunda EE Spring Boot process applications with Gradle.
 
-**Note:** create a *gradle.properties* file in the project folder with you own appropriate variables:
+**Note:** create a *gradle.properties* file in the root project folder with your own appropriate connection variables 
+to get the camunda-bpm-ee artifacts for building the template.
 ```
-CamundaNexusUser="variable"
-CamundaNexusPassword="variable"
+CamundaNexusUser="your_username"
+CamundaNexusPassword="your_password"
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # camunda-spring-boot-quickstarter
 Dockerized quick-start template for a Camunda EE Spring Boot process applications with Gradle.
+
+**Note:** create a *gradle.properties* file in the project folder with you own appropriate variables:
+```
+CamundaNexusUser="variable"
+CamundaNexusPassword="variable"
+```


### PR DESCRIPTION
Extended README.md about gradle.properties to set variables for the build process without the file the project couldn't build.
The Variables are for the connection to Camunda EE Nexus.